### PR TITLE
Use nucleus sampling instead of top-k

### DIFF
--- a/bloomy.py
+++ b/bloomy.py
@@ -22,6 +22,7 @@ def generate(text, sample=False):
         "parameters": {
             "max_new_tokens": 32,
             "do_sample": sample,
+            "top_p": 0.95,
             "early_stopping": False,
             "length_penalty": 0.0,
             "eos_token_id": None,


### PR DESCRIPTION
By default, sampling uses top-k sampling with k=50. This PR changes the payload to use nucleus sampling with top_p = 0.95